### PR TITLE
Deprecated use of sklearn for installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
 graphlearning
-sklearn
+scikit-learn
 matplotlib
 torch
 torchvision


### PR DESCRIPTION
During installation of requirements.txt. via pip, a simple deprecation error appeared: The 'sklearn' PyPI package is deprecated, use 'scikit-learn' rather than 'sklearn' for pip commands. 

I simply added the required 'scikit-learn' to the requirements.txt so that the installation uses non-deprecated names.